### PR TITLE
Upgrade Elasticsearch to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You need to install a version matching your Elasticsearch version:
 | es-2.0.2        |     0.20.2         |
 | es-2.1.0        |     0.21.0         |
 | es-2.1.1        |     0.21.1         |
+| es-2.2.0        |     0.22.0         |
 
 
 ## Prerequisites

--- a/pom.xml
+++ b/pom.xml
@@ -6,16 +6,18 @@
 
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-japanese-suggester</artifactId>
-    <version>0.21.1</version>
+    <version>0.22.0</version>
 
 
     <packaging>jar</packaging>
 
     <properties>
-        <elasticsearch.version>2.1.1</elasticsearch.version>
-        <lucene.version>5.3.1</lucene.version>
+        <elasticsearch.version>2.2.0</elasticsearch.version>
+        <lucene.version>5.4.1</lucene.version>
         <jackson.version>2.6.2</jackson.version>
-        <testframework.version>2.1.16</testframework.version>
+        <testframework.version>2.2.0</testframework.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -92,8 +94,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
 

--- a/src/test/java/org/elasticsearch/search/suggest/completion/JapaneseCompletionSuggesterTest.java
+++ b/src/test/java/org/elasticsearch/search/suggest/completion/JapaneseCompletionSuggesterTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @LuceneTestCase.SuppressCodecs("*")
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
 public class JapaneseCompletionSuggesterTest extends ESIntegTestCase {
 
     @Override


### PR DESCRIPTION
- Use Jackson streaming API to avoid reflection (Elasticsearch tighten security)
- Fix java version issue in plugin-descriptor.properties
